### PR TITLE
Add initial governance documents

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,227 @@
+# Technical Charter (the “Charter”) for Minder a Series of LF Projects, LLC
+
+Last Updated: 10 Oct 2024
+
+This Charter sets forth the responsibilities and procedures for technical
+contribution to, and oversight of, the Minder open source project, which has
+been established as Minder a Series of LF Projects, LLC (the “Project”). LF
+Projects, LLC (“LF Projects”) is a Delaware series limited liability company.
+All contributors (including committers, maintainers, and other technical
+positions) and other participants in the Project (collectively, “Collaborators”)
+must comply with the terms of this Charter.
+
+## Mission and Scope of the Project
+
+a. The mission of the Project is to enable project owners to proactively manage
+their security posture by providing a set of checks and policies to minimize
+risk along the software supply chain, and attest their security practices to
+downstream consumers.
+
+a. The scope of the Project includes collaborative development under the Project
+License (as defined herein) supporting the mission, including documentation,
+testing, integration and the creation of other artifacts that aid the
+development, deployment, operation or adoption of the open source project.
+
+## Steering Committee
+
+a. The Steering Committee (the “SC”) will be responsible for all technical
+oversight of the open source Project, and for updates and amendments to this
+charter.
+
+a. The SC voting members are initially the Project’s Committers. At the
+inception of the project, the Committers of the Project will be as set forth
+within the “[MAINTAINERS](./MAINTAINERS.md)" file within the Project’s
+`community` repository. The SC may choose an alternative approach for
+determining the voting members of the SC, and any such alternative approach will
+be documented in the MAINTAINERS file. Any meetings of the Technical Steering
+Committee are intended to be open to the public, and can be conducted
+electronically, via teleconference, or in person.
+
+a. SC projects generally will involve Contributors and Committers. The SC may
+adopt or modify roles so long as the roles are documented in the MAINTAINERS
+file. Unless otherwise documented:
+
+i. Contributors include anyone in the technical community that contributes code,
+documentation, or other technical artifacts to the Project;
+
+i. Committers are Contributors who have earned the ability to modify (“commit”)
+source code, documentation or other technical artifacts in a project’s
+repository; and
+
+i. A Contributor may become a Committer by a majority approval of the existing
+Committers. A Committer may be removed by a majority approval of the other
+existing Committers. Committers may also resign their role by transmitting this
+intention to the SC.
+
+a. Participation in the Project through becoming a Contributor and Committer is
+open to anyone so long as they abide by the terms of this Charter.
+
+a. The SC may (1) establish work flow procedures for the submission, approval,
+and closure/archiving of projects, (2) set requirements for the promotion of
+Contributors to Committer status, as applicable, and (3) amend, adjust, refine
+and/or eliminate the roles of Contributors, and Committers, and create new
+roles, and publicly document any SC roles, as it sees fit.
+
+a. The SC may elect a SC Chair, who will preside over meetings of the SC and
+will serve until their resignation or replacement by the SC. The SC Chair, or
+any other SC member so designated by the SC, will serve as the primary
+communication contact between the Project and Open Source Security Foundation
+(OpenSSF), a directed fund of The Linux Foundation.
+
+a. Responsibilities: The SC will be responsible for all aspects of oversight
+relating to the Project, which may include:
+
+i. coordinating the technical direction of the Project;
+
+i. approving project or system proposals (including, but not limited to,
+incubation, deprecation, and changes to a sub-project’s scope);
+
+i. organizing sub-projects and removing sub-projects;
+
+i. creating sub-committees or working groups to focus on cross-project technical
+issues and requirements;
+
+i. appointing representatives to work with other open source or open standards
+communities;
+
+i. establishing community norms, workflows, issuing releases, and security issue
+reporting policies;
+
+i. approving and implementing policies and processes for contributing (to be
+published in the CONTRIBUTING file) and coordinating with the series manager of
+the Project (as provided for in the Series Agreement, the “Series Manager”) to
+resolve matters or concerns that may arise as set forth in Section 7 of this
+Charter;
+
+i. discussions, seeking consensus, and where necessary, voting on technical
+matters relating to the code base that affect multiple projects; and
+
+i. coordinating any marketing, events, or communications regarding the Project.
+
+## SC Voting
+
+a. While the Project aims to operate as a consensus-based community, if any SC
+decision requires a vote to move the Project forward, the voting members of the
+SC will vote on a one vote per voting member basis. All votes shall be performed
+electronically (for example, using a GitHub issue to record votes).
+
+a. Quorum for SC meetings requires at least fifty percent of all voting members
+of the SC to be present. The SC may continue to meet if quorum is not met but
+will be prevented from making any decisions at the meeting.
+
+a. Except as provided in Section 7.c. and 8.a, decisions made by electronic vote
+require a majority vote of all voting members of the SC.
+
+a. In the event a vote cannot be resolved by the SC, any voting member of the SC
+may refer the matter to the Series Manager for assistance in reaching a
+resolution.
+
+## Compliance with Policies
+
+a. This Charter is subject to the Series Agreement for the Project and the
+Operating Agreement of LF Projects. Contributors will comply with the policies
+of LF Projects as may be adopted and amended by LF Projects, including, without
+limitation the policies listed at https://lfprojects.org/policies/.
+
+a. The SC may adopt a code of conduct (“CoC”) for the Project, which is subject
+to approval by the Series Manager. In the event that a Project-specific CoC has
+not been approved, the LF Projects Code of Conduct listed at
+https://lfprojects.org/policies will apply for all Collaborators in the Project.
+
+a. When amending or adopting any policy applicable to the Project, LF Projects
+will publish such policy, as to be amended or adopted, on its web site at least
+30 days prior to such policy taking effect; provided, however, that in the case
+of any amendment of the Trademark Policy or Terms of Use of LF Projects, any
+such amendment is effective upon publication on LF Project’s web site.
+
+a. All Collaborators must allow open participation from any individual or
+organization meeting the requirements for contributing under this Charter and
+any policies adopted for all Collaborators by the SC, regardless of competitive
+interests. Put another way, the Project community must not seek to exclude any
+participant based on any criteria, requirement, or reason other than those that
+are reasonable and applied on a non-discriminatory basis to all Collaborators in
+the Project community.
+
+a. The Project will operate in a transparent, open, collaborative, and ethical
+manner at all times. The output of all Project discussions, proposals,
+timelines, decisions, and status should be made open and easily visible to all.
+Any potential violations of this requirement should be reported immediately to
+the Series Manager.
+
+## Community Assets
+
+a. LF Projects will hold title to all trade or service marks used by the Project
+(“Project Trademarks”), whether based on common law or registered rights.
+Project Trademarks will be transferred and assigned to LF Projects to hold on
+behalf of the Project. Any use of any Project Trademarks by Collaborators in the
+Project will be in accordance with the license from LF Projects and inure to the
+benefit of LF Projects.
+
+a. The Project will, as permitted and in accordance with such license from LF
+Projects, develop and own all Project GitHub and social media accounts, and
+domain name registrations created by the Project community.
+
+a. Under no circumstances will LF Projects be expected or required to undertake
+any action on behalf of the Project that is inconsistent with the tax-exempt
+status or purpose, as applicable, of the Joint Development Foundation or LF
+Projects, LLC.
+
+## General Rules and Operations.
+
+a. The Project will:
+
+i. engage in the work of the Project in a professional manner consistent with
+maintaining a cohesive community, while also maintaining the goodwill and esteem
+of LF Projects, Joint Development Foundation and other partner organizations in
+the open source community; and
+
+i. respect the rights of all trademark owners, including any branding and
+trademark usage guidelines.
+
+## Intellectual Property Policy
+
+a. Collaborators acknowledge that the copyright in all new contributions will be
+retained by the copyright holder as independent works of authorship and that no
+contributor or copyright holder will be required to assign copyrights to the
+Project.
+
+a. Except as described in Section 7.c., all contributions to the Project are
+subject to the following:
+
+i. All new inbound code contributions to the Project must be made using Apache
+License, Version 2.0 available at http://www.apache.org/licenses/LICENSE-2.0
+(the “Project License”).
+
+i. All new inbound code contributions must also be accompanied by a Developer
+Certificate of Origin (http://developercertificate.org) sign-off in the source
+code system that is submitted through a SC-approved contribution process which
+will bind the authorized contributor and, if not self-employed, their employer
+to the applicable license;
+
+i. All outbound code will be made available under the Project License.
+
+i. Documentation will be received and made available by the Project under the
+Creative Commons Attribution 4.0 International License (available at
+http://creativecommons.org/licenses/by/4.0/).
+
+i. The Project may seek to integrate and contribute back to other open source
+projects (“Upstream Projects”). In such cases, the Project will conform to all
+license requirements of the Upstream Projects, including dependencies, leveraged
+by the Project. Upstream Project code contributions not stored within the
+Project’s main code repository will comply with the contribution process and
+license terms for the applicable Upstream Project.
+
+a. The SC may approve the use of an alternative license or licenses for inbound
+or outbound contributions on an exception basis. To request an exception, please
+describe the contribution, the alternative open source license(s), and the
+justification for using an alternative open source license for the Project.
+License exceptions must be approved by a two-thirds vote of the entire SC.
+
+a. Contributed files should contain license information, such as SPDX short form
+identifiers, indicating the open source license or licenses pertaining to the
+file.
+
+## Amendments
+
+a. This charter may be amended by a two-thirds vote of the entire SC and is
+subject to approval by LF Projects.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,81 @@
+# Minder Contribution and Maintainership
+
+We welcome additional contributors to Minder, including maintainers. Minder
+currently has a two-tier contributor structure:
+
+| Role        | Description                                                      | Privileges                          |
+| ----------- | ---------------------------------------------------------------- | ----------------------------------- |
+| Contributor | Anyone who participates in the project!                          | Send / update PRs                   |
+| Maintainer  | Consistent contributors who have shown commitment to the project | Review and merge PRs, manage issues |
+
+## Contributors
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for a desrciption of how to get started
+contributing to Minder.
+
+## Requirements for Becoming a Maintainer
+
+To become a maintainer, you must meet the following criteria:
+
+1. **Account Security**
+
+- Must have enabled
+  [two factor authentication](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/about-two-factor-authentication)
+  on their GitHub account
+
+1. **Demonstrated Contribution**:
+
+   - Have made multiple significant contributions to Minder's GitHub
+     repositories. This can include:
+     - PR contributions to at least one Minder subystem
+     - PR reviews of at least one Minder subsystem
+     - Documentation and issue triage
+
+1. **Sponsorship**:
+
+   - Sponsored by at least one existing maintainer.
+
+Candidates who have met these criteria must be approved by a majority of the
+current Maintainers, [as documented in the Charter](./GOVERNANCE.md).
+
+## Responsibilities of a Maintainer
+
+As a maintainer, you will have the following responsibilities:
+
+1. **Code Review and Merging**:
+
+   - Review pull requests for quality, correctness, and alignment with the
+     project direction.
+     - When in doubt, assign pull requests to subject matter experts in the
+       relevant subsystem.
+   - Merge reviewed pull requests when satisfactory.
+
+1. **Set Technical Direction**:
+
+   - Where appropriate, participate in authoring and reviewing technical design
+     documents.
+     - Note: many project documents are currently in the Stacklok Google Drive
+       instance. We are working to open the relevant documents for community
+       review and feedback.
+
+## Maintainers List
+
+The current list of maintainers is:
+
+- @JAORMX (Stacklok)
+- @jhrozek (Stacklok)
+- @rdimitrov (Stacklok)
+- @dmjb (Stacklok)
+- @evankanderson (Stacklok)
+- @eleftherias (Stacklok)
+- @yrobla (Stacklok)
+- @lukehinds (Stacklok)
+- @blkt (Stacklok)
+- @puerco (Stacklok)
+- @Vyom-Yadav (Canonical)
+
+Assignment of permissions for these maintainers is currently privately managed
+by Stacklok as a matter of circumstance; changes to this list will need a
+Stacker to apply some private automation to grant the privileges, until we find
+a different approach (for example, donation to a foundation, which would have
+their own automation).

--- a/README.md
+++ b/README.md
@@ -1,2 +1,52 @@
-# community
-Minder Community rules and infrastructure
+# What is Minder?
+
+Minder is an OpenSSF platform that helps development teams and open source
+communities build more secure software, and prove to others that what they’ve
+built is secure. As a platform, Minder enables project owners to define and
+enforce their own security policies, enabling both detection and remediation of
+supply chain elements which violate policy.
+
+Minder is designed as a multi-tenant platform, where each project is isolated
+from other projects on the service. Within a project, Minder supports granting
+permissions to multiple users, and allowing those users to instantiate
+_providers_ with credentials to manage supply chain _entities_ such as
+repositories, artifacts, and pull requests. Minder _profiles_ encapsulate a set
+of rules which apply to one or more entity types to enforce supply chain policy.
+
+Minder can be deployed as a Helm chart and provides a CLI tool `minder`.
+Stacklok, also provides a free-for-public-repositories hosted version of Minder
+(at https://api.stacklok.com/). Minder is designed to be extensible, allowing
+users to integrate with their existing tooling and processes.
+
+## Features
+
+- **Repo configuration and security:** Simplify configuration and management of
+  security settings and policies across repos.
+- **Proactive security enforcement:** Continuously enforce best practice
+  security configurations by setting granular policies to alert only or
+  auto-remediate.
+- **Artifact attestation:** Continuously verify that packages are signed to
+  ensure they’re tamper-proof, using the open source project Sigstore.
+- **Dependency management:** Manage dependency security posture by helping
+  developers make better choices and enforcing controls. Minder is integrated
+  with [Trusty by Stacklok](https://trustypkg.dev) to enable policy-driven
+  dependency management based on the risk level of dependencies.
+
+# Roadmap
+
+The Minder community are actively working on new features and improvements for
+Minder.
+
+You can find our roadmap [here](https://minder-docs.stacklok.dev/about/roadmap).
+
+Should you wish to request or contribute a feature or improvement, please use
+the following
+[issue template](https://github.com/stacklok/minder/issues/new?template=enhancement.yml)
+
+## Contributing
+
+We welcome contributions to Minder. Please see our
+[Contributing](./CONTRIBUTING.md) guide for more information. Contributors who
+participate frequently in pull requests should read the
+[Maintainers](./MAINTAINERS.md) document for the process and expectations of
+acquiring Maintainer permissions.


### PR DESCRIPTION
Per discussion with Stacklok experts and LF legal, commit initial version of governance documentation.

Changes from default LF charter:

1. All voting is to be performed electronically, rather than having separate majority-of-quorum voting for in-person meetings.  Our preference is to establish consistent voting thresholds and enable asynchronous participation, as well as simplifying the governance process.
2. A slight majority of polled participants preferred the term "Steering Committee" over "Technical Steering Committee", given that the body has the explicit responsibility for updating the governance documents as well as driving technical decisions.
3. Added an explicit mechanism for Committers to resign their role if desired.

Changes from [current MAINTAINERS.md](https://github.com/stacklok/minder/tree/main/MAINTAINERS.md):

1. Remove dangling "Maintainers" word, clarify that Maintainers/Committers need to be voted in by SC.

Changes from [current Minder README.md](https://github.com/stacklok/minder/tree/main/README.md):

1. Removed all "how to run" details, kept the high-level vision and links to contributing / etc documents.