### PR TITLE
Add Terraform to manage mindersec users

### DIFF
--- a/.github/workflows/provision_users.yaml
+++ b/.github/workflows/provision_users.yaml
@@ -1,0 +1,56 @@
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    # 15:00 UTC = 6PM/7PM Eastern Europe, 8AM/9AM Pacific
+    - cron: "0 15 * * *"
+
+jobs:
+  provision_users:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    env:
+      CONFIG_DIRECTORY: "./config/"
+    steps:
+      - name: SetupOpenTofu
+        uses: opentofu/setup-opentofu@12f4debbf681675350b6cd1f0ff8ecfbda62027b # v1.0.4
+
+      - name: Checkout code
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4
+
+      - name: Load state from artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: provision-user-state
+          path: $CONFIG_DIRECTORY
+          pattern: terraform.tfstate
+
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app_id: ${{ secrets.USER_MANAGEMENT_APP_ID }}
+          private_key: ${{ secrets.USER_MANAGEMENT_PRIVATE_KEY }}
+
+      - name: OpenTofu Apply
+        id: apply
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: |
+          set -e
+          cd $CONFIG_DIRECTORY
+
+          tofu init
+          tofu validate -no-color
+          tofu apply -no-color -input=false -auto-approve
+
+      # NOTE: we don't encrypt/decrypt the state file, as it only contains
+      # (public) github memberships.
+      - name: Save state to artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: provision-user-state
+          path: $CONFIG_DIRECTORY/terraform.tfstate

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*

--- a/config/.terraform.lock.hcl
+++ b/config/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/integrations/github" {
+  version     = "6.2.3"
+  constraints = "6.2.3"
+  hashes = [
+    "h1:qBH3fN/NItflQkBoIVdQa7n8WvBOuu7Ao20oeoAubKM=",
+    "zh:05874671652a260b12d784cc46b0eea156f493a5f12e00368d1f6cb319156257",
+    "zh:0c7a3cae5a66e5c5efc3b25ba646a0d46bfe1fd3edba1f5a75f51aede85a9d1b",
+    "zh:174310010d08f13e36e53ff18e44a21dd040c89884ef190a192c6ce27926a912",
+    "zh:23d1d8731e518354ce6a83419f49101aece63882b0ca7c489f3c598cc6ea5d5e",
+    "zh:4e88953816daf11ab1681c32c7988d4e29476fc44f0959fe03173532cf5044de",
+    "zh:6fab07734ccf27f5afee4442abae2d33245eabf35519032ce1e2aad6961a640a",
+    "zh:7b2f324b918e161c892c29ee80d36c48ca8b891b8047e132fc701ca741e5ae72",
+    "zh:8ef4f0d691ade98082ef1f6b36e556468e5ab26e60021f0de0fb22e3acdfd990",
+    "zh:8f0f3e139faa8f2b9075bb9978dd683f4bab5ac91171bbb969addd04d7f0b90f",
+    "zh:97cb6d7fdf640237cc2f0ab830db8f878770968c59fd28298e9dddb8b9e6294d",
+    "zh:a17038d8747c6bb660e4c5981e8ffbbc33c66ba164868fd35d442e7f828a1e01",
+    "zh:aa9f4b7d947f7b11277b4e9ba7147f5594cf60a6589b7aac4344f73d1400d1c0",
+    "zh:c780b951e14d583ef6ffef9a934831b56ee157c50ed8e969c676a636810f7db1",
+    "zh:d8497bb2986fd76107b7208b33cc39281797164fdea09453e987b969a461befb",
+    "zh:fbd1fee2c9df3aa19cf8851ce134dea6e45ea01cb85695c1726670c285797e25",
+  ]
+}

--- a/config/README.md
+++ b/config/README.md
@@ -1,0 +1,10 @@
+# Terraform Provisioning of Users
+
+We are using Terraform (with a GitHub App) to provision users and teams in the
+`mindersec` organization. We do this for a few reasons:
+
+1. It makes the configuration and membership in the organization transparent.
+1. It allows code review for changes (granting permissions /
+   [promoting to Maintainer](../MAINTAINERS.md))
+1. It allows us to reduce the number of users with "admin" permissions on the
+   organization.

--- a/config/providers.tf
+++ b/config/providers.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_providers {
+    github = {
+      source  = "integrations/github"
+      version = "6.2.3"
+    }
+
+    # N.B. we don't have a solution for state storage yet.
+  }
+}
+
+provider "github" {
+  owner = "mindersec"
+}

--- a/config/users.tf
+++ b/config/users.tf
@@ -1,0 +1,55 @@
+locals {
+  maintainers = {
+    JAORMX        = { role : "admin" }
+    jhrozek       = { role : "member" }
+    rdimitrov     = { role : "member" }
+    dmjb          = { role : "member" }
+    evankanderson = { role : "admin" }
+    eleftherias   = { role : "member" }
+    yrobla        = { role : "member" }
+    lukehinds     = { role : "admin" }
+    blkt          = { role : "member" }
+    puerco        = { role : "member" }
+    Vyom-Yadav    = { role : "member" }
+
+    thelinuxfoundation = { role : "admin" }
+  }
+}
+
+resource "github_membership" "maintainers" {
+  for_each = local.maintainers
+
+  username = each.key
+  role     = each.value.role
+}
+
+import {
+  to = github_membership.maintainers["evankanderson"]
+  id = "mindersec:evankanderson"
+}
+import {
+  to = github_membership.maintainers["JAORMX"]
+  id = "mindersec:JAORMX"
+}
+
+resource "github_team" "maintainers" {
+  name        = "maintainers"
+  description = "MinderSec maintainers"
+  // Either "secret" (can't be nested, others can't see it)
+  // or "closed" (visible within the org)
+  privacy = "closed"
+}
+
+resource "github_team_members" "maintainers" {
+  team_id = github_team.maintainers.id
+
+  dynamic "members" {
+    for_each = local.maintainers
+
+    content {
+      username = members.key
+      # Admins will always be listed as "maintainers" by the GitHub API.
+      role = replace(local.maintainers[members.key].role, "admin", "maintainer")
+    }
+  }
+}


### PR DESCRIPTION
Add infrastructure-as-code to manage the membership of the `mindersec` organization.
