### PR TITLE
Fix bootstrapping for terraform action.

### DIFF
--- a/.github/workflows/provision_users.yaml
+++ b/.github/workflows/provision_users.yaml
@@ -22,6 +22,7 @@ jobs:
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4
 
       - name: Load state from artifacts
+        continue-on-error: true # Allow for artifact not existing yet
         uses: actions/download-artifact@v4
         with:
           name: provision-user-state


### PR DESCRIPTION
Ref: https://github.com/mindersec/community/actions/runs/11298504654/job/31427601768

We won't have the `state` artifact on first run, so allow the step to fail without cancelling the action.
