### PR TITLE
Fix numbered list Markdown in GOVERNANCE

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -12,216 +12,223 @@ must comply with the terms of this Charter.
 
 ## Mission and Scope of the Project
 
-a. The mission of the Project is to enable project owners to proactively manage
-their security posture by providing a set of checks and policies to minimize
-risk along the software supply chain, and attest their security practices to
-downstream consumers.
+1. The mission of the Project is to enable project owners to proactively manage
+   their security posture by providing a set of checks and policies to minimize
+   risk along the software supply chain, and attest their security practices to
+   downstream consumers.
 
-a. The scope of the Project includes collaborative development under the Project
-License (as defined herein) supporting the mission, including documentation,
-testing, integration and the creation of other artifacts that aid the
-development, deployment, operation or adoption of the open source project.
+1. The scope of the Project includes collaborative development under the Project
+   License (as defined herein) supporting the mission, including documentation,
+   testing, integration and the creation of other artifacts that aid the
+   development, deployment, operation or adoption of the open source project.
 
 ## Steering Committee
 
-a. The Steering Committee (the “SC”) will be responsible for all technical
-oversight of the open source Project, and for updates and amendments to this
-charter.
+1. The Steering Committee (the “SC”) will be responsible for all technical
+   oversight of the open source Project, and for updates and amendments to this
+   charter.
 
-a. The SC voting members are initially the Project’s Committers. At the
-inception of the project, the Committers of the Project will be as set forth
-within the “[MAINTAINERS](./MAINTAINERS.md)" file within the Project’s
-`community` repository. The SC may choose an alternative approach for
-determining the voting members of the SC, and any such alternative approach will
-be documented in the MAINTAINERS file. Any meetings of the Technical Steering
-Committee are intended to be open to the public, and can be conducted
-electronically, via teleconference, or in person.
+1. The SC voting members are initially the Project’s Committers. At the
+   inception of the project, the Committers of the Project will be as set forth
+   within the “[MAINTAINERS](./MAINTAINERS.md)" file within the Project’s
+   `community` repository. The SC may choose an alternative approach for
+   determining the voting members of the SC, and any such alternative approach
+   will be documented in the MAINTAINERS file. Any meetings of the Technical
+   Steering Committee are intended to be open to the public, and can be
+   conducted electronically, via teleconference, or in person.
 
-a. SC projects generally will involve Contributors and Committers. The SC may
-adopt or modify roles so long as the roles are documented in the MAINTAINERS
-file. Unless otherwise documented:
+1. SC projects generally will involve Contributors and Committers. The SC may
+   adopt or modify roles so long as the roles are documented in the MAINTAINERS
+   file. Unless otherwise documented:
 
-i. Contributors include anyone in the technical community that contributes code,
-documentation, or other technical artifacts to the Project;
+   1. Contributors include anyone in the technical community that contributes
+      code, documentation, or other technical artifacts to the Project;
 
-i. Committers are Contributors who have earned the ability to modify (“commit”)
-source code, documentation or other technical artifacts in a project’s
-repository; and
+   1. Committers are Contributors who have earned the ability to modify
+      (“commit”) source code, documentation or other technical artifacts in a
+      project’s repository; and
 
-i. A Contributor may become a Committer by a majority approval of the existing
-Committers. A Committer may be removed by a majority approval of the other
-existing Committers. Committers may also resign their role by transmitting this
-intention to the SC.
+   1. A Contributor may become a Committer by a majority approval of the
+      existing Committers. A Committer may be removed by a majority approval of
+      the other existing Committers. Committers may also resign their role by
+      transmitting this intention to the SC.
 
-a. Participation in the Project through becoming a Contributor and Committer is
-open to anyone so long as they abide by the terms of this Charter.
+   1. Participation in the Project through becoming a Contributor and Committer
+      is open to anyone so long as they abide by the terms of this Charter.
 
-a. The SC may (1) establish work flow procedures for the submission, approval,
-and closure/archiving of projects, (2) set requirements for the promotion of
-Contributors to Committer status, as applicable, and (3) amend, adjust, refine
-and/or eliminate the roles of Contributors, and Committers, and create new
-roles, and publicly document any SC roles, as it sees fit.
+   1. The SC may (1) establish work flow procedures for the submission,
+      approval, and closure/archiving of projects, (2) set requirements for the
+      promotion of Contributors to Committer status, as applicable, and (3)
+      amend, adjust, refine and/or eliminate the roles of Contributors, and
+      Committers, and create new roles, and publicly document any SC roles, as
+      it sees fit.
 
-a. The SC may elect a SC Chair, who will preside over meetings of the SC and
-will serve until their resignation or replacement by the SC. The SC Chair, or
-any other SC member so designated by the SC, will serve as the primary
-communication contact between the Project and Open Source Security Foundation
-(OpenSSF), a directed fund of The Linux Foundation.
+   1. The SC may elect a SC Chair, who will preside over meetings of the SC and
+      will serve until their resignation or replacement by the SC. The SC Chair,
+      or any other SC member so designated by the SC, will serve as the primary
+      communication contact between the Project and Open Source Security
+      Foundation (OpenSSF), a directed fund of The Linux Foundation.
 
-a. Responsibilities: The SC will be responsible for all aspects of oversight
-relating to the Project, which may include:
+   1. Responsibilities: The SC will be responsible for all aspects of oversight
+      relating to the Project, which may include:
 
-i. coordinating the technical direction of the Project;
+   1. coordinating the technical direction of the Project;
 
-i. approving project or system proposals (including, but not limited to,
-incubation, deprecation, and changes to a sub-project’s scope);
+   1. approving project or system proposals (including, but not limited to,
+      incubation, deprecation, and changes to a sub-project’s scope);
 
-i. organizing sub-projects and removing sub-projects;
+   1. organizing sub-projects and removing sub-projects;
 
-i. creating sub-committees or working groups to focus on cross-project technical
-issues and requirements;
+   1. creating sub-committees or working groups to focus on cross-project
+      technical issues and requirements;
 
-i. appointing representatives to work with other open source or open standards
-communities;
+   1. appointing representatives to work with other open source or open
+      standards communities;
 
-i. establishing community norms, workflows, issuing releases, and security issue
-reporting policies;
+   1. establishing community norms, workflows, issuing releases, and security
+      issue reporting policies;
 
-i. approving and implementing policies and processes for contributing (to be
-published in the CONTRIBUTING file) and coordinating with the series manager of
-the Project (as provided for in the Series Agreement, the “Series Manager”) to
-resolve matters or concerns that may arise as set forth in Section 7 of this
-Charter;
+   1. approving and implementing policies and processes for contributing (to be
+      published in the CONTRIBUTING file) and coordinating with the series
+      manager of the Project (as provided for in the Series Agreement, the
+      “Series Manager”) to resolve matters or concerns that may arise as set
+      forth in Section 7 of this Charter;
 
-i. discussions, seeking consensus, and where necessary, voting on technical
-matters relating to the code base that affect multiple projects; and
+   1. discussions, seeking consensus, and where necessary, voting on technical
+      matters relating to the code base that affect multiple projects; and
 
-i. coordinating any marketing, events, or communications regarding the Project.
+   1. coordinating any marketing, events, or communications regarding the
+      Project.
 
 ## SC Voting
 
-a. While the Project aims to operate as a consensus-based community, if any SC
-decision requires a vote to move the Project forward, the voting members of the
-SC will vote on a one vote per voting member basis. All votes shall be performed
-electronically (for example, using a GitHub issue to record votes).
+1. While the Project aims to operate as a consensus-based community, if any SC
+   decision requires a vote to move the Project forward, the voting members of
+   the SC will vote on a one vote per voting member basis. All votes shall be
+   performed electronically (for example, using a GitHub issue to record votes).
 
-a. Quorum for SC meetings requires at least fifty percent of all voting members
-of the SC to be present. The SC may continue to meet if quorum is not met but
-will be prevented from making any decisions at the meeting.
+1. Quorum for SC meetings requires at least fifty percent of all voting members
+   of the SC to be present. The SC may continue to meet if quorum is not met but
+   will be prevented from making any decisions at the meeting.
 
-a. Except as provided in Section 7.c. and 8.a, decisions made by electronic vote
-require a majority vote of all voting members of the SC.
+1. Except as provided in Section 7.c. and 8.a, decisions made by electronic vote
+   require a majority vote of all voting members of the SC.
 
-a. In the event a vote cannot be resolved by the SC, any voting member of the SC
-may refer the matter to the Series Manager for assistance in reaching a
-resolution.
+1. In the event a vote cannot be resolved by the SC, any voting member of the SC
+   may refer the matter to the Series Manager for assistance in reaching a
+   resolution.
 
 ## Compliance with Policies
 
-a. This Charter is subject to the Series Agreement for the Project and the
-Operating Agreement of LF Projects. Contributors will comply with the policies
-of LF Projects as may be adopted and amended by LF Projects, including, without
-limitation the policies listed at https://lfprojects.org/policies/.
+1. This Charter is subject to the Series Agreement for the Project and the
+   Operating Agreement of LF Projects. Contributors will comply with the
+   policies of LF Projects as may be adopted and amended by LF Projects,
+   including, without limitation the policies listed at
+   https://lfprojects.org/policies/.
 
-a. The SC may adopt a code of conduct (“CoC”) for the Project, which is subject
-to approval by the Series Manager. In the event that a Project-specific CoC has
-not been approved, the LF Projects Code of Conduct listed at
-https://lfprojects.org/policies will apply for all Collaborators in the Project.
+1. The SC may adopt a code of conduct (“CoC”) for the Project, which is subject
+   to approval by the Series Manager. In the event that a Project-specific CoC
+   has not been approved, the LF Projects Code of Conduct listed at
+   https://lfprojects.org/policies will apply for all Collaborators in the
+   Project.
 
-a. When amending or adopting any policy applicable to the Project, LF Projects
-will publish such policy, as to be amended or adopted, on its web site at least
-30 days prior to such policy taking effect; provided, however, that in the case
-of any amendment of the Trademark Policy or Terms of Use of LF Projects, any
-such amendment is effective upon publication on LF Project’s web site.
+1. When amending or adopting any policy applicable to the Project, LF Projects
+   will publish such policy, as to be amended or adopted, on its web site at
+   least 30 days prior to such policy taking effect; provided, however, that in
+   the case of any amendment of the Trademark Policy or Terms of Use of LF
+   Projects, any such amendment is effective upon publication on LF Project’s
+   web site.
 
-a. All Collaborators must allow open participation from any individual or
-organization meeting the requirements for contributing under this Charter and
-any policies adopted for all Collaborators by the SC, regardless of competitive
-interests. Put another way, the Project community must not seek to exclude any
-participant based on any criteria, requirement, or reason other than those that
-are reasonable and applied on a non-discriminatory basis to all Collaborators in
-the Project community.
+1. All Collaborators must allow open participation from any individual or
+   organization meeting the requirements for contributing under this Charter and
+   any policies adopted for all Collaborators by the SC, regardless of
+   competitive interests. Put another way, the Project community must not seek
+   to exclude any participant based on any criteria, requirement, or reason
+   other than those that are reasonable and applied on a non-discriminatory
+   basis to all Collaborators in the Project community.
 
-a. The Project will operate in a transparent, open, collaborative, and ethical
-manner at all times. The output of all Project discussions, proposals,
-timelines, decisions, and status should be made open and easily visible to all.
-Any potential violations of this requirement should be reported immediately to
-the Series Manager.
+1. The Project will operate in a transparent, open, collaborative, and ethical
+   manner at all times. The output of all Project discussions, proposals,
+   timelines, decisions, and status should be made open and easily visible to
+   all. Any potential violations of this requirement should be reported
+   immediately to the Series Manager.
 
 ## Community Assets
 
-a. LF Projects will hold title to all trade or service marks used by the Project
-(“Project Trademarks”), whether based on common law or registered rights.
-Project Trademarks will be transferred and assigned to LF Projects to hold on
-behalf of the Project. Any use of any Project Trademarks by Collaborators in the
-Project will be in accordance with the license from LF Projects and inure to the
-benefit of LF Projects.
+1. LF Projects will hold title to all trade or service marks used by the Project
+   (“Project Trademarks”), whether based on common law or registered rights.
+   Project Trademarks will be transferred and assigned to LF Projects to hold on
+   behalf of the Project. Any use of any Project Trademarks by Collaborators in
+   the Project will be in accordance with the license from LF Projects and inure
+   to the benefit of LF Projects.
 
-a. The Project will, as permitted and in accordance with such license from LF
-Projects, develop and own all Project GitHub and social media accounts, and
-domain name registrations created by the Project community.
+1. The Project will, as permitted and in accordance with such license from LF
+   Projects, develop and own all Project GitHub and social media accounts, and
+   domain name registrations created by the Project community.
 
-a. Under no circumstances will LF Projects be expected or required to undertake
-any action on behalf of the Project that is inconsistent with the tax-exempt
-status or purpose, as applicable, of the Joint Development Foundation or LF
-Projects, LLC.
+1. Under no circumstances will LF Projects be expected or required to undertake
+   any action on behalf of the Project that is inconsistent with the tax-exempt
+   status or purpose, as applicable, of the Joint Development Foundation or LF
+   Projects, LLC.
 
 ## General Rules and Operations.
 
-a. The Project will:
+1. The Project will:
 
-i. engage in the work of the Project in a professional manner consistent with
-maintaining a cohesive community, while also maintaining the goodwill and esteem
-of LF Projects, Joint Development Foundation and other partner organizations in
-the open source community; and
+   1. engage in the work of the Project in a professional manner consistent with
+      maintaining a cohesive community, while also maintaining the goodwill and
+      esteem of LF Projects, Joint Development Foundation and other partner
+      organizations in the open source community; and
 
-i. respect the rights of all trademark owners, including any branding and
-trademark usage guidelines.
+   1. respect the rights of all trademark owners, including any branding and
+      trademark usage guidelines.
 
 ## Intellectual Property Policy
 
-a. Collaborators acknowledge that the copyright in all new contributions will be
-retained by the copyright holder as independent works of authorship and that no
-contributor or copyright holder will be required to assign copyrights to the
-Project.
+1. Collaborators acknowledge that the copyright in all new contributions will be
+   retained by the copyright holder as independent works of authorship and that
+   no contributor or copyright holder will be required to assign copyrights to
+   the Project.
 
-a. Except as described in Section 7.c., all contributions to the Project are
-subject to the following:
+1. Except as described in Section 7.c., all contributions to the Project are
+   subject to the following:
 
-i. All new inbound code contributions to the Project must be made using Apache
-License, Version 2.0 available at http://www.apache.org/licenses/LICENSE-2.0
-(the “Project License”).
+   1. All new inbound code contributions to the Project must be made using
+      Apache License, Version 2.0 available at
+      http://www.apache.org/licenses/LICENSE-2.0 (the “Project License”).
 
-i. All new inbound code contributions must also be accompanied by a Developer
-Certificate of Origin (http://developercertificate.org) sign-off in the source
-code system that is submitted through a SC-approved contribution process which
-will bind the authorized contributor and, if not self-employed, their employer
-to the applicable license;
+   1. All new inbound code contributions must also be accompanied by a Developer
+      Certificate of Origin (http://developercertificate.org) sign-off in the
+      source code system that is submitted through a SC-approved contribution
+      process which will bind the authorized contributor and, if not
+      self-employed, their employer to the applicable license;
 
-i. All outbound code will be made available under the Project License.
+   1. All outbound code will be made available under the Project License.
 
-i. Documentation will be received and made available by the Project under the
-Creative Commons Attribution 4.0 International License (available at
-http://creativecommons.org/licenses/by/4.0/).
+   1. Documentation will be received and made available by the Project under the
+      Creative Commons Attribution 4.0 International License (available at
+      http://creativecommons.org/licenses/by/4.0/).
 
-i. The Project may seek to integrate and contribute back to other open source
-projects (“Upstream Projects”). In such cases, the Project will conform to all
-license requirements of the Upstream Projects, including dependencies, leveraged
-by the Project. Upstream Project code contributions not stored within the
-Project’s main code repository will comply with the contribution process and
-license terms for the applicable Upstream Project.
+   1. The Project may seek to integrate and contribute back to other open source
+      projects (“Upstream Projects”). In such cases, the Project will conform to
+      all license requirements of the Upstream Projects, including dependencies,
+      leveraged by the Project. Upstream Project code contributions not stored
+      within the Project’s main code repository will comply with the
+      contribution process and license terms for the applicable Upstream
+      Project.
 
-a. The SC may approve the use of an alternative license or licenses for inbound
-or outbound contributions on an exception basis. To request an exception, please
-describe the contribution, the alternative open source license(s), and the
-justification for using an alternative open source license for the Project.
-License exceptions must be approved by a two-thirds vote of the entire SC.
+1. The SC may approve the use of an alternative license or licenses for inbound
+   or outbound contributions on an exception basis. To request an exception,
+   please describe the contribution, the alternative open source license(s), and
+   the justification for using an alternative open source license for the
+   Project. License exceptions must be approved by a two-thirds vote of the
+   entire SC.
 
-a. Contributed files should contain license information, such as SPDX short form
-identifiers, indicating the open source license or licenses pertaining to the
-file.
+1. Contributed files should contain license information, such as SPDX short form
+   identifiers, indicating the open source license or licenses pertaining to the
+   file.
 
 ## Amendments
 
-a. This charter may be amended by a two-thirds vote of the entire SC and is
-subject to approval by LF Projects.
+1. This charter may be amended by a two-thirds vote of the entire SC and is
+   subject to approval by LF Projects.


### PR DESCRIPTION
It turns out that Markdown doesn't allow letter-prefixed lists, so the "a." and "i." prefixes in the initial LF document didn't map to anything useful.  Switch to numbers.

Note: I have a `.prettierrc` that text-wraps to 80 character lines, so I ended up reflowing all of the lines.  If it's too annoying, I'll turn it off.
