### PR TITLE
Add CODEOWNERS policies and document permissions to become an org member to manage issues

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,17 +1,38 @@
 # Minder Contribution and Maintainership
 
 We welcome additional contributors to Minder, including maintainers. Minder
-currently has a two-tier contributor structure:
+currently has a three-tier contributor structure:
 
-| Role        | Description                                                      | Privileges                          |
-| ----------- | ---------------------------------------------------------------- | ----------------------------------- |
-| Contributor | Anyone who participates in the project!                          | Send / update PRs                   |
-| Maintainer  | Consistent contributors who have shown commitment to the project | Review and merge PRs, manage issues |
+| Role        | Description                                                                      | Privileges                          |
+| ----------- | -------------------------------------------------------------------------------- | ----------------------------------- |
+| Contributor | Anyone who participates in the project!                                          | Send / update PRs                   |
+| Org Member  | Particpates in the project with non-code contributions, such as issue management | Manage issues                       |
+| Maintainer  | Consistent contributors who have shown commitment to the project                 | Review and merge PRs, manage issues |
 
 ## Contributors
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md) for a desrciption of how to get started
 contributing to Minder.
+
+## Requirements for Becoming an Org Member
+
+To become an org member, you must meet the following criteria:
+
+1. **Account Security**
+
+   - Must have enabled
+     [two factor authentication](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/about-two-factor-authentication)
+     on their GitHub account
+
+1. **Demonstrated Contribution**:
+
+   - Have participated meaningfully in resolving multiple issues in the
+     `mindersec` organization.
+
+Candidates who have met these criteria may request membership in the GitHub
+organization by updating the [terraform configuration](./config/users.tf). These
+PRs must be reviewed by a Maintainer, and are subject to review by the
+Maintainers / Steering Committee.
 
 ## Requirements for Becoming a Maintainer
 
@@ -19,9 +40,9 @@ To become a maintainer, you must meet the following criteria:
 
 1. **Account Security**
 
-- Must have enabled
-  [two factor authentication](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/about-two-factor-authentication)
-  on their GitHub account
+   - Must have enabled
+     [two factor authentication](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/about-two-factor-authentication)
+     on their GitHub account
 
 1. **Demonstrated Contribution**:
 

--- a/policies/profiles/code_protection.yaml
+++ b/policies/profiles/code_protection.yaml
@@ -1,0 +1,13 @@
+version: v1
+type: profile
+name: mindersec-code-review
+display_name: Enforce mindersec Code Review Standards
+context:
+  provider: github
+alert: "off"
+remediate: "off"
+repository:
+  - type: codeowners
+    def: {}
+  - type: branch_protection
+    def: {}

--- a/policies/profiles/code_protection.yaml
+++ b/policies/profiles/code_protection.yaml
@@ -5,7 +5,7 @@ display_name: Enforce mindersec Code Review Standards
 context:
   provider: github
 alert: "off"
-remediate: "off"
+remediate: "on"
 repository:
   - type: codeowners
     def: {}

--- a/policies/profiles/code_protection.yaml
+++ b/policies/profiles/code_protection.yaml
@@ -11,3 +11,6 @@ repository:
     def: {}
   - type: branch_protection
     def: {}
+    # N.B. the gh_branch_protection remediation type expects this property to exist
+    params:
+      branch: "" # Use default for repo

--- a/policies/ruletypes/branch_protection.yaml
+++ b/policies/ruletypes/branch_protection.yaml
@@ -36,8 +36,8 @@ def:
       - ingested:
           def: ".allow_force_pushes.enabled"
         constant: false
-      - ingestion:
-          def: "enforce_admins.enabled"
+      - ingested:
+          def: ".enforce_admins.enabled"
         constant: true
       - ingested:
           def: ".required_pull_request_reviews.required_approving_review_count"
@@ -48,8 +48,8 @@ def:
       - ingested:
           def: ".required_pull_request_reviews.require_code_owner_reviews"
         constant: true
-      - ingestion:
-          def: "required_pull_request_reviews.require_last_push_approval"
+      - ingested:
+          def: ".required_pull_request_reviews.require_last_push_approval"
         constant: true
   # Defines the configuration for remediating the rule
   remediate:

--- a/policies/ruletypes/branch_protection.yaml
+++ b/policies/ruletypes/branch_protection.yaml
@@ -1,0 +1,69 @@
+---
+version: v1
+type: rule-type
+name: branch_protection
+severity:
+  value: high
+context:
+  provider: github
+description: Ensure that branch protection is enabled in mindersec
+guidance: |
+  Enforce that mindersec has branch protection enabled with the following
+  settings:
+
+  - Disallow deletion of the protected branch
+  - Require pull request reviews before merging, with at least 1 reviewer
+  - Require code owner reviews
+  - Dismiss stale reviews
+def:
+  in_entity: repository
+  rule_schema: {}
+  ingest:
+    type: rest
+    rest:
+      endpoint: "/repos/{{.Entity.Owner}}/{{.Entity.Name}}/branches/main/protection"
+      parse: json
+      fallback:
+        - http_code: 404
+          body: |
+            {"http_status": 404, "message": "Not Protected"}
+  eval:
+    type: jq
+    jq:
+      - ingested:
+          def: ".allow_deletions.enabled"
+        constant: false
+      - ingested:
+          def: ".allow_force_pushes.enabled"
+        constant: false
+      - ingestion:
+          def: "enforce_admins.enabled"
+        constant: true
+      - ingested:
+          def: ".required_pull_request_reviews.required_approving_review_count"
+        constant: 1
+      - ingested:
+          def: ".required_pull_request_reviews.dismiss_stale_reviews"
+        constant: true
+      - ingested:
+          def: ".required_pull_request_reviews.require_code_owner_reviews"
+        constant: true
+      - ingestion:
+          def: "required_pull_request_reviews.require_last_push_approval"
+        constant: true
+  # Defines the configuration for remediating the rule
+  remediate:
+    type: gh_branch_protection
+    gh_branch_protection:
+      patch: |
+        {
+          "allow_deletions": false,
+          "allow_force_pushes": false,
+          "enforce_admins": true,
+          "required_pull_request_reviews": {
+            "required_approving_review_count": 1,
+            "dismiss_stale_reviews": true,
+            "require_code_owner_reviews": true,
+            "require_last_push_approval": true
+          }
+        }

--- a/policies/ruletypes/branch_protection.yaml
+++ b/policies/ruletypes/branch_protection.yaml
@@ -18,6 +18,13 @@ guidance: |
 def:
   in_entity: repository
   rule_schema: {}
+  param_schema:
+    properties:
+      # N.B. the gh_branch_protection remediation type expects this property to exist
+      branch:
+        type: string
+        description: "The name of the branch to protect.  If left empty, the default branch will be used."
+        default: ""
   ingest:
     type: rest
     rest:

--- a/policies/ruletypes/codeowners.yaml
+++ b/policies/ruletypes/codeowners.yaml
@@ -1,0 +1,48 @@
+version: v1
+type: rule-type
+name: codeowners
+severity:
+  value: high
+context:
+  provider: github
+description: Ensure that all mindersec repos have a CODEOWNERS file.
+guidance: |
+  The CODEOWNERS file defines what users are permitted to approve PRs in that
+  repository.  We are using CODEOWNERS to limit code review to maintainers,
+  so that non-maintainer members can manage issues and PRs.  See
+  https://github.com/mindersec/community/issues/5 for background.
+
+  This rule ensures that all repositories have a CODEOWNERS file.
+def:
+  in_entity: repository
+  rule_schema: {}
+  ingest:
+    type: git
+    git:
+      branch: main
+  eval:
+    type: rego
+    rego:
+      type: deny-by-default
+      def: |
+        package minder
+
+        import rego.v1
+
+        default allow := false
+        allow if {
+          file.exists(".github/CODEOWNERS")
+        }
+  remediate:
+    type: pull_request
+    pull_request:
+      title: Add CODEOWNERS file
+      body: |
+        Enforces that all `mindersec` repos have a CODEOWNERS file.
+        See https://github.com/mindersec/community/tree/main/policies/ruletypes/codeowners.yaml
+        for more information.
+      contents:
+        - path: .github/CODEOWNERS
+          content: |
+            # This file is used to define who can approve PRs in this repository.
+            * @mindersec/maintainers


### PR DESCRIPTION
Fixes #5

As this is changing `mindersec` policy, we'll need a majority of Maintainers to approve this PR.
