### PR TITLE
Fix import to reference correct github_membership

### DIFF
--- a/config/users.tf
+++ b/config/users.tf
@@ -40,15 +40,15 @@ resource "github_membership" "org_members" {
 
 # Folks who helped with the transition need a manual import
 import {
-  to = github_membership.maintainers["dussab"]
+  to = github_membership.org_members["dussab"]
   id = "mindersec:dussab"
 }
 import {
-  to = github_membership.maintainers["ethomson"]
+  to = github_membership.org_members["ethomson"]
   id = "mindersec:ethomson"
 }
 import {
-  to = github_membership.maintainers["staceypotter"]
+  to = github_membership.org_members["staceypotter"]
   id = "mindersec:staceypotter"
 }
 


### PR DESCRIPTION
Ref: https://github.com/mindersec/community/actions/runs/11535376447/job/32110390959

It turns out that I renamed some imports, but they actually belonged to an object with a different name.
