### PR TITLE
Commit text as provided by LF in https://github.com/mindersec/minder/pull/4834

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,6 @@
 # This file is used to define who can approve PRs in this repository.
 * @mindersec/maintainers
+
+# LF Projects would like to approve all governance changes.  See
+# https://github.com/mindersec/minder/pull/4834
+GOVERNANCE.md @thelinuxfoundation

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,6 +1,6 @@
 # Technical Charter (the “Charter”) for Minder a Series of LF Projects, LLC
 
-Last Updated: 10 Oct 2024
+Adopted October 25, 2024
 
 This Charter sets forth the responsibilities and procedures for technical
 contribution to, and oversight of, the Minder open source project, which has
@@ -12,32 +12,32 @@ must comply with the terms of this Charter.
 
 ## Mission and Scope of the Project
 
-1. The mission of the Project is to enable project owners to proactively manage
-   their security posture by providing a set of checks and policies to minimize
-   risk along the software supply chain, and attest their security practices to
-   downstream consumers.
+1. The mission of the Project is to enable teams and organizations to define
+   security policies in a consistent way across multiple supply chain assets.
+   Minder helps project owners proactively manage their security posture by
+   providing a set of checks and policies to minimize risk along the software
+   supply chain, and attest their security practices to downstream consumers.
 
 1. The scope of the Project includes collaborative development under the Project
    License (as defined herein) supporting the mission, including documentation,
    testing, integration and the creation of other artifacts that aid the
    development, deployment, operation or adoption of the open source project.
 
-## Steering Committee
+## Technical Steering Committee
 
-1. The Steering Committee (the “SC”) will be responsible for all technical
-   oversight of the open source Project, and for updates and amendments to this
-   charter.
+1. The Technical Steering Committee (the “TSC”) will be responsible for all
+   technical oversight of the open source Project.
 
-1. The SC voting members are initially the Project’s Committers. At the
+1. The TSC voting members are initially the Project’s Committers. At the
    inception of the project, the Committers of the Project will be as set forth
-   within the “[MAINTAINERS](./MAINTAINERS.md)" file within the Project’s
-   `community` repository. The SC may choose an alternative approach for
-   determining the voting members of the SC, and any such alternative approach
-   will be documented in the MAINTAINERS file. Any meetings of the Technical
-   Steering Committee are intended to be open to the public, and can be
-   conducted electronically, via teleconference, or in person.
+   within the “[MAINTAINERS](./MAINTAINERS.md)” file within the Project’s code
+   repository. The TSC may choose an alternative approach for determining the
+   voting members of the TSC, and any such alternative approach will be
+   documented in the MAINTAINERS file. Any meetings of the Technical Steering
+   Committee are intended to be open to the public, and can be conducted
+   electronically, via teleconference, or in person.
 
-1. SC projects generally will involve Contributors and Committers. The SC may
+1. TSC projects generally will involve Contributors and Committers. The TSC may
    adopt or modify roles so long as the roles are documented in the MAINTAINERS
    file. Unless otherwise documented:
 
@@ -49,28 +49,26 @@ must comply with the terms of this Charter.
       project’s repository; and
 
    1. A Contributor may become a Committer by a majority approval of the
-      existing Committers. A Committer may be removed by a majority approval of
-      the other existing Committers. Committers may also resign their role by
-      transmitting this intention to the SC.
+      existing Committers. A Committer may be removed by either (a) resigning or
+      (b) a majority approval of the other existing Committers.
 
-   1. Participation in the Project through becoming a Contributor and Committer
-      is open to anyone so long as they abide by the terms of this Charter.
+1. Participation in the Project through becoming a Contributor and Committer is
+   open to anyone so long as they abide by the terms of this Charter.
 
-   1. The SC may (1) establish work flow procedures for the submission,
-      approval, and closure/archiving of projects, (2) set requirements for the
-      promotion of Contributors to Committer status, as applicable, and (3)
-      amend, adjust, refine and/or eliminate the roles of Contributors, and
-      Committers, and create new roles, and publicly document any SC roles, as
-      it sees fit.
+1. The TSC may (1) establish work flow procedures for the submission, approval,
+   and closure/archiving of projects, (2) set requirements for the promotion of
+   Contributors to Committer status, as applicable, and (3) amend, adjust,
+   refine and/or eliminate the roles of Contributors, and Committers, and create
+   new roles, and publicly document any TSC roles, as it sees fit.
 
-   1. The SC may elect a SC Chair, who will preside over meetings of the SC and
-      will serve until their resignation or replacement by the SC. The SC Chair,
-      or any other SC member so designated by the SC, will serve as the primary
-      communication contact between the Project and Open Source Security
-      Foundation (OpenSSF), a directed fund of The Linux Foundation.
+1. The TSC may elect a TSC Chair, who will preside over meetings of the TSC and
+   will serve until their resignation or replacement by the TSC. The TSC Chair,
+   or any other TSC member so designated by the TSC, will serve as the primary
+   communication contact between the Project and OpenSSF, a directed fund of The
+   Linux Foundation.
 
-   1. Responsibilities: The SC will be responsible for all aspects of oversight
-      relating to the Project, which may include:
+1. Responsibilities: The TSC will be responsible for all aspects of oversight
+   relating to the Project, which may include:
 
    1. coordinating the technical direction of the Project;
 
@@ -89,10 +87,10 @@ must comply with the terms of this Charter.
       issue reporting policies;
 
    1. approving and implementing policies and processes for contributing (to be
-      published in the CONTRIBUTING file) and coordinating with the series
-      manager of the Project (as provided for in the Series Agreement, the
-      “Series Manager”) to resolve matters or concerns that may arise as set
-      forth in Section 7 of this Charter;
+      published in the [MAINTAINERS file](./MAINTAINERS.md) and coordinating
+      with the series manager of the Project (as provided for in the Series
+      Agreement, the “Series Manager”) to resolve matters or concerns that may
+      arise as set forth in Section 7 of this Charter;
 
    1. discussions, seeking consensus, and where necessary, voting on technical
       matters relating to the code base that affect multiple projects; and
@@ -100,22 +98,23 @@ must comply with the terms of this Charter.
    1. coordinating any marketing, events, or communications regarding the
       Project.
 
-## SC Voting
+## TSC Voting
 
-1. While the Project aims to operate as a consensus-based community, if any SC
+1. While the Project aims to operate as a consensus-based community, if any TSC
    decision requires a vote to move the Project forward, the voting members of
-   the SC will vote on a one vote per voting member basis. All votes shall be
-   performed electronically (for example, using a GitHub issue to record votes).
+   the TSC will vote on a one vote per voting member basis.
 
-1. Quorum for SC meetings requires at least fifty percent of all voting members
-   of the SC to be present. The SC may continue to meet if quorum is not met but
-   will be prevented from making any decisions at the meeting.
+1. Quorum for TSC meetings requires at least fifty percent of all voting members
+   of the TSC to be present. The TSC may continue to meet if quorum is not met
+   but will be prevented from making any decisions at the meeting.
 
-1. Except as provided in Section 7.c. and 8.a, decisions made by electronic vote
-   require a majority vote of all voting members of the SC.
+1. Except as provided in Section 7.c. and 8.a, decisions by vote at a meeting
+   require a majority vote of those in attendance, provided quorum is met.
+   Decisions made by electronic vote without a meeting require a majority vote
+   of all voting members of the TSC.
 
-1. In the event a vote cannot be resolved by the SC, any voting member of the SC
-   may refer the matter to the Series Manager for assistance in reaching a
+1. In the event a vote cannot be resolved by the TSC, any voting member of the
+   TSC may refer the matter to the Series Manager for assistance in reaching a
    resolution.
 
 ## Compliance with Policies
@@ -126,7 +125,7 @@ must comply with the terms of this Charter.
    including, without limitation the policies listed at
    https://lfprojects.org/policies/.
 
-1. The SC may adopt a code of conduct (“CoC”) for the Project, which is subject
+1. The TSC may adopt a code of conduct (“CoC”) for the Project, which is subject
    to approval by the Series Manager. In the event that a Project-specific CoC
    has not been approved, the LF Projects Code of Conduct listed at
    https://lfprojects.org/policies will apply for all Collaborators in the
@@ -141,7 +140,7 @@ must comply with the terms of this Charter.
 
 1. All Collaborators must allow open participation from any individual or
    organization meeting the requirements for contributing under this Charter and
-   any policies adopted for all Collaborators by the SC, regardless of
+   any policies adopted for all Collaborators by the TSC, regardless of
    competitive interests. Put another way, the Project community must not seek
    to exclude any participant based on any criteria, requirement, or reason
    other than those that are reasonable and applied on a non-discriminatory
@@ -199,7 +198,7 @@ must comply with the terms of this Charter.
 
    1. All new inbound code contributions must also be accompanied by a Developer
       Certificate of Origin (http://developercertificate.org) sign-off in the
-      source code system that is submitted through a SC-approved contribution
+      source code system that is submitted through a TSC-approved contribution
       process which will bind the authorized contributor and, if not
       self-employed, their employer to the applicable license;
 
@@ -217,12 +216,12 @@ must comply with the terms of this Charter.
       contribution process and license terms for the applicable Upstream
       Project.
 
-1. The SC may approve the use of an alternative license or licenses for inbound
+1. The TSC may approve the use of an alternative license or licenses for inbound
    or outbound contributions on an exception basis. To request an exception,
    please describe the contribution, the alternative open source license(s), and
    the justification for using an alternative open source license for the
    Project. License exceptions must be approved by a two-thirds vote of the
-   entire SC.
+   entire TSC.
 
 1. Contributed files should contain license information, such as SPDX short form
    identifiers, indicating the open source license or licenses pertaining to the
@@ -230,5 +229,5 @@ must comply with the terms of this Charter.
 
 ## Amendments
 
-1. This charter may be amended by a two-thirds vote of the entire SC and is
+1. This charter may be amended by a two-thirds vote of the entire TSC and is
    subject to approval by LF Projects.


### PR DESCRIPTION
Check in the official LF governance docs, as per https://github.com/mindersec/minder/pull/4834.  Check in the files as markdown, such that it is easier to track future edits.  Per request in that file, limit approvals for governance changes to require approval by @thelinuxfoundation explicitly.

It appears that some of the suggested Stacklok changes didn't make it into the official LF document.  Adding @riaankleinhans to suggest what to do:

1. The maintainers preferred the name "Steering Committee" to "Technical Steering Committee", as the responsibilities including maintaining and updating committer and community roles and non-technical processes.
1. The project is keeping governance documents, including the maintainers list, in the `community` repository, rather than in "the project's code repository" (as the project has several code repositories).
1. The maintainers preferred to resolve all votes with electronic voting, removing the "majority-of-quorum" voting option for in-person voting (it seemed more likely to cause confusion and strife, and is less async-friendly).
