### PR TITLE
Fix mesembria username and import team if needed

### DIFF
--- a/config/users.tf
+++ b/config/users.tf
@@ -19,7 +19,7 @@ locals {
     dashtangui   = {}
     dussab       = {}
     ethomson     = {}
-    msembria     = {}
+    mesembria    = {}
     staceypotter = {}
   }
 }
@@ -72,4 +72,10 @@ resource "github_team_members" "maintainers" {
       role = replace(local.maintainers[members.key].role, "admin", "maintainer")
     }
   }
+}
+
+// Import the team, because it didn't get stored in terraform state.
+import {
+  to = github_team.maintainers
+  id = "maintainers"
 }


### PR DESCRIPTION
Ref: https://github.com/mindersec/community/actions/runs/11557075823/job/32166248700

1-letter typo (failed copy-paste) from #5 for the org membership part. I created the team before we were saving GitHub state, and OpenTofu can't figure out if it's the same team or not.
