### PR TITLE
Move 4 Stackers to emeritus

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -84,13 +84,9 @@ As a maintainer, you will have the following responsibilities:
 The current list of maintainers is:
 
 - @JAORMX (Stacklok)
-- @jhrozek (Stacklok)
 - @rdimitrov (Stacklok)
-- @dmjb (Stacklok)
 - @evankanderson (Stacklok)
 - @eleftherias (Stacklok)
-- @yrobla (Stacklok)
-- @lukehinds (Stacklok)
 - @blkt (Stacklok)
 - @puerco (Stacklok)
 - @Vyom-Yadav (Canonical)
@@ -100,3 +96,13 @@ by Stacklok as a matter of circumstance; changes to this list will need a
 Stacker to apply some private automation to grant the privileges, until we find
 a different approach (for example, donation to a foundation, which would have
 their own automation).
+
+### Emeritus Maintainers
+
+The following maintainers contributed to the design and implementation of Minder,
+but have since moved on to other projects.  We thank them for their efforts!
+
+- @dmjb (Stacklok)
+- @jhrozek (Stacklok)
+- @lukehinds (Stacklok)
+- @yrobla (Stacklok)


### PR DESCRIPTION
Luke, Yolanda, Don, and Jakub were awesome in the development of Minder, but they're no longer focused on the project, so move them to emeritus.

(This will need a vote or approval from the listed participants.)