### PR TITLE
GitHub permissions cleanup

### DIFF
--- a/config/users.tf
+++ b/config/users.tf
@@ -6,8 +6,7 @@ locals {
     dmjb          = { role : "member" }
     evankanderson = { role : "admin" }
     eleftherias   = { role : "member" }
-    yrobla        = { role : "member" }
-    lukehinds     = { role : "admin" }
+    lukehinds     = { role : "member" }
     blkt          = { role : "member" }
     puerco        = { role : "member" }
     Vyom-Yadav    = { role : "member" }
@@ -20,7 +19,6 @@ locals {
     dashtangui   = {}
     dussab       = {}
     ethomson     = {}
-    mesembria    = {}
     staceypotter = {}
   }
 }


### PR DESCRIPTION
I noticed that Yolanda and Philippe never accepted their org invites.  I don't think we need to keep spamming them.

Also, as Luke is emeritus, move him from "owner" to "member", keeping Ozz, Evan, and Rado as owners.