### PR TITLE
Add new members based on recent contribution

### DIFF
--- a/config/users.tf
+++ b/config/users.tf
@@ -16,10 +16,17 @@ locals {
   }
 
   org_members = {
-    dashtangui   = {}
-    dussab       = {}
-    ethomson     = {}
-    staceypotter = {}
+    dakshhhhh16    = {}
+    dashtangui     = {}
+    DharunMR       = {}
+    dussab         = {}
+    ethomson       = {}
+    Gitjay11       = {}
+    Jaydeep869     = {}
+    kazuhidelee    = {}
+    krrish175-byte = {}
+    sachin9058     = {}
+    staceypotter   = {}
   }
 }
 


### PR DESCRIPTION
The following folks (mostly LFX mentorship applicants) have all contributed multiple substantive PRs to Minder, and have generally done a great job handling feedback and meeting the codebase standards.  You can check this here, if GitHub manages to to load the data (not a given, but not within our control):

https://github.com/mindersec/minder/graphs/contributors
